### PR TITLE
Update dependencies to TypeScript/ReactNative supporting libs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ TBD
 ## Background
 
 A `did:web` method driver for use with in-browser and server-side on Node.js
-with the [`did-io`](https://github.com/digitalbazaar/did-io) resolver library. 
+with the [`did-io`](https://github.com/digitalcredentials/did-io) resolver library. 
 
 Draft spec (W3C CCG Work Item):
 
@@ -37,9 +37,9 @@ Other implementations:
 
 ```js
 import { Ed25519VerificationKey2020 }
-  from '@digitalbazaar/ed25519-verification-key-2020'
+  from '@digitalcredentials/ed25519-verification-key-2020'
 import { X25519KeyAgreementKey2020 }
-  from '@digitalbazaar/x25519-key-agreement-key-2020'
+  from '@digitalcredentials/x25519-key-agreement-key-2020'
 import { CryptoLD } from 'crypto-ld'
 
 import * as didWeb from '@interop/did-web-resolver'
@@ -51,7 +51,7 @@ cryptoLd.use(X25519KeyAgreementKey2020)
 const didWebDriver = didWeb.driver({ cryptoLd })
 
 // Optionally use it with the CachedResolver from did-io
-import {CachedResolver} from '@digitalbazaar/did-io';
+import {CachedResolver} from '@digitalcredentials/did-io';
 const resolver = new CachedResolver()
 resolver.use(didWebDriver)
 ```

--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
     }
   },
   "dependencies": {
-    "@digitalbazaar/did-io": "digitalbazaar/did-io#noesm",
-    "@digitalbazaar/http-client": "digitalbazaar/http-client#noesm",
-    "did-context": "digitalbazaar/did-context#nofs",
+    "@digitalcredentials/did-io": "^1.0.2",
+    "@digitalcredentials/http-client": "^1.2.2",
+    "did-context": "^3.1.1",
     "ed25519-signature-2020-context": "^1.1.0",
-    "x25519-key-agreement-2020-context": "digitalbazaar/x25519-key-agreement-2020-context#nofs"
+    "x25519-key-agreement-2020-context": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.7",
@@ -54,8 +54,8 @@
     "@babel/plugin-transform-runtime": "^7.16.7",
     "@babel/preset-env": "^7.16.7",
     "@babel/runtime": "^7.16.7",
-    "@digitalbazaar/ed25519-verification-key-2020": "^3.2.0",
-    "@digitalbazaar/x25519-key-agreement-key-2020": "^2.0.0",
+    "@digitalcredentials/ed25519-verification-key-2020": "^3.2.2",
+    "@digitalcredentials/x25519-key-agreement-key-2020": "^2.0.2",
     "babel-loader": "^8.2.3",
     "chai": "^4.3.4",
     "cross-env": "^7.0.3",

--- a/src/DidWebResolver.js
+++ b/src/DidWebResolver.js
@@ -1,5 +1,5 @@
-import { httpClient } from '@digitalbazaar/http-client'
-import * as didIo from '@digitalbazaar/did-io'
+import { httpClient } from '@digitalcredentials/http-client'
+import * as didIo from '@digitalcredentials/did-io'
 import ed25519Context from 'ed25519-signature-2020-context'
 import x25519Context from 'x25519-key-agreement-2020-context'
 import didContext from 'did-context'

--- a/test/unit/DidWebResolver.spec.js
+++ b/test/unit/DidWebResolver.spec.js
@@ -4,9 +4,9 @@ import dirtyChai from 'dirty-chai'
 import { DidWebResolver, urlFromDid, didFromUrl } from '../../src'
 
 import { Ed25519VerificationKey2020 }
-  from '@digitalbazaar/ed25519-verification-key-2020'
+  from '@digitalcredentials/ed25519-verification-key-2020'
 import { X25519KeyAgreementKey2020 }
-  from '@digitalbazaar/x25519-key-agreement-key-2020'
+  from '@digitalcredentials/x25519-key-agreement-key-2020'
 import { CryptoLD } from 'crypto-ld'
 chai.use(dirtyChai)
 chai.should()


### PR DESCRIPTION
* Switch libraries to `@digitalcredentials` versions.
* Remove github deps (Docker-friendly).

Addresses issue https://github.com/interop-alliance/did-web-resolver/issues/14