### PR TITLE
Replace builtin URL with whatwg-url (for ReactNative).

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@digitalcredentials/http-client": "^1.2.2",
     "did-context": "^3.1.1",
     "ed25519-signature-2020-context": "^1.1.0",
+    "whatwg-url": "^11.0.0",
     "x25519-key-agreement-2020-context": "^1.0.0"
   },
   "devDependencies": {

--- a/src/DidWebResolver.js
+++ b/src/DidWebResolver.js
@@ -4,6 +4,7 @@ import ed25519Context from 'ed25519-signature-2020-context'
 import x25519Context from 'x25519-key-agreement-2020-context'
 import didContext from 'did-context'
 import { decodeSecretKeySeed } from '@digitalcredentials/bnid'
+import { URL } from 'whatwg-url'
 
 const { VERIFICATION_RELATIONSHIPS } = didIo
 


### PR DESCRIPTION
Fixes errors on React Native (which doesn't have a proper `URL` global implementation, unlike Node and the browser).