### PR TITLE
Fix urlFromDid() logic to correctly handle path segments

### DIFF
--- a/src/DidWebResolver.js
+++ b/src/DidWebResolver.js
@@ -54,7 +54,11 @@ export function urlFromDid ({ did } = {}) {
   // const [didResource, query] = didUrl.split('?')
 
   // eslint-disable-next-line no-unused-vars
-  const [_did, _web, urlNoProtocol] = didUrl.split(':')
+  const [_did, _web, urlNoProtocol, ...pathFragments] = didUrl.split(':')
+
+  if (urlNoProtocol.includes('/')) {
+    throw new TypeError(`Cannot construct url from did: "${did}". domain-name cannot contain a path.`)
+  }
 
   let parsedUrl
   try {
@@ -65,11 +69,10 @@ export function urlFromDid ({ did } = {}) {
     throw new TypeError(`Cannot construct url from did: "${did}".`)
   }
 
-  if (!parsedUrl.pathname || parsedUrl.pathname === '/') {
+  if (pathFragments.length === 0) {
     parsedUrl.pathname = '/.well-known/did.json'
   } else {
-    const pathFragments = parsedUrl.pathname.split('/')
-    parsedUrl.pathname = pathFragments.map(decodeURIComponent).join('/')
+    parsedUrl.pathname = pathFragments.map(decodeURIComponent).join('/') + '/did.json'
   }
 
   if (hashFragment) {


### PR DESCRIPTION
Wrote a few tests and implemented logic to support optional paths according to Web DID Method Specification.

Previously the urlFromDid() logic supported: 
did:web:domain/path/subpath -> https://domain/path/subpath

This is an invalid DID.

With this PR urlFromDid() supports:
did:web:domain:path:subpath -> https://domain/path/subpath/did.json
